### PR TITLE
fix(typo): https:: typo in CONTRIBUTING.md doc link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](https:://apalis.dev).
+> If you want to ask a question, we assume that you have read the available [Documentation](https://apalis.dev).
 
 Before you ask a question, it is best to search for existing [Issues](/issues) and [Discussions](/discussions) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 


### PR DESCRIPTION
Line 27 of CONTRIBUTING.md links to `https:://apalis.dev` (extra colon) for the Documentation reference. Fixed to `https://apalis.dev`. Verified the target returns HTTP 200.