### PR TITLE
feat (api)!: remove queue input in expose endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+- **feat (api)!**: remove queue input in expose endpoints ([#737](https://github.com/geofmureithi/apalis/pull/737))
 - **feat**: idempotency for sql tasks ([#736](https://github.com/geofmureithi/apalis/pull/736))
 - **chore**: bump to v1.0.0 rc.8 ([#734](https://github.com/geofmureithi/apalis/pull/734))
 - **feat**: idempotency for tasks ([#726](https://github.com/apalis-dev/apalis/pull/726))

--- a/apalis-core/src/backend/expose.rs
+++ b/apalis-core/src/backend/expose.rs
@@ -27,10 +27,7 @@ pub trait ListQueues: Backend {
 /// Allows listing all workers registered with the backend
 pub trait ListWorkers: Backend {
     /// List all registered workers in the current queue
-    fn list_workers(
-        &self,
-        queue: &str,
-    ) -> impl Future<Output = Result<Vec<RunningWorker>, Self::Error>> + Send;
+    fn list_workers(&self) -> impl Future<Output = Result<Vec<RunningWorker>, Self::Error>> + Send;
 
     /// List all registered workers in all queues
     fn list_all_workers(
@@ -43,7 +40,6 @@ pub trait ListTasks<Args>: Backend {
     #[allow(clippy::type_complexity)]
     fn list_tasks(
         &self,
-        queue: &str,
         filter: &Filter,
     ) -> impl Future<Output = Result<Vec<Task<Args, Self::Context, Self::IdType>>, Self::Error>> + Send;
 }
@@ -66,10 +62,7 @@ pub trait Metrics: Backend {
     fn global(&self) -> impl Future<Output = Result<Vec<Statistic>, Self::Error>> + Send;
 
     /// Collects and returns statistics for a specific queue
-    fn fetch_by_queue(
-        &self,
-        queue: &str,
-    ) -> impl Future<Output = Result<Vec<Statistic>, Self::Error>> + Send;
+    fn fetch_by_queue(&self) -> impl Future<Output = Result<Vec<Statistic>, Self::Error>> + Send;
 }
 
 /// Represents information about a specific queue in the backend

--- a/apalis/src/lib.rs
+++ b/apalis/src/lib.rs
@@ -25,13 +25,12 @@ pub mod prelude {
     pub use crate::layers::WorkerBuilderExt;
     pub use apalis_core::{
         backend::{
-            Backend, FetchById, ListTasks, ListWorkers, Metrics, RegisterWorker, Reschedule,
-            ResumeAbandoned, ResumeById, TaskSink, Update, WaitForCompletion,
+            Backend, BackendExt, Expose, FetchById, Filter, ListAllTasks, ListQueues, ListTasks,
+            ListWorkers, Metrics, QueueInfo, RegisterWorker, Reschedule, ResumeAbandoned,
+            ResumeById, RunningWorker, StatType, Statistic, TaskResult, TaskSink, TaskSinkError,
+            TaskStream, Update, WaitForCompletion,
         },
-        backend::{
-            TaskResult, TaskStream, codec::*, custom::*, memory::MemoryStorage, pipe::*,
-            poll_strategy::*, shared::MakeShared,
-        },
+        backend::{codec::*, custom::*, memory::*, pipe::*, poll_strategy::*, shared::*},
         error::*,
         layers::*,
         monitor::{ExitError, Monitor, MonitorError, MonitoredWorkerError, shutdown::Shutdown},


### PR DESCRIPTION
## Description

feat (api)!: remove queue input in expose endpoints

This is a breaking change that removes the queue input in traits like `ListTasks` and `ListWorkers`

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the existing tests and they pass
- [x] I have run `cargo fmt` and `cargo clippy`

## Checklist

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes

Any additional information, context, or screenshots about the pull request here.